### PR TITLE
[Needs Work] hidden email input for password managers

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -18,7 +18,7 @@
         type: "email",
         id: "email",
         value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -17,6 +17,7 @@
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do %>
       <%= render "devise/shared/error_messages", resource: resource %>
+      <%= email_field_tag :"user[email]", "USERS-EMAIL-HERE", style: "display:none", autocomplete: "off", "aria-hidden": true %>
       <%= hidden_field_tag "user[reset_password_token]", params[:reset_password_token] %>
 
       <%= render "govuk_publishing_components/components/input", {

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -23,7 +23,7 @@
         type: "email",
         id: "email",
         error_message: devise_error_items(:email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -31,7 +31,7 @@
         id: "email",
         value: @email,
         error_message: devise_error_items(:email),
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/input", {

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -18,6 +18,8 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
+      <%= email_field_tag :"user[email]", "USERS-EMAIL-HERE", style: "display:none", autocomplete: "off", "aria-hidden": true %>
+    
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("devise.registrations.edit.fields.password.label"),

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -7,7 +7,7 @@
         <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
       <% end %>
 
-      <%= email_field_tag :"user[email]", @login_state.user.email, style: "display:none", autocomplete: "off", "aria-hidden": true %>
+      <%= email_field_tag :"user[email]", "USERS-EMAIL-HERE", style: "display:none", autocomplete: "off", "aria-hidden": true %>
     
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/devise/registrations/start.html.erb
+++ b/app/views/devise/registrations/start.html.erb
@@ -7,6 +7,8 @@
         <%= render "devise/shared/error_messages", resource: resource, resource_error_messages: @resource_error_messages %>
       <% end %>
 
+      <%= email_field_tag :"user[email]", @login_state.user.email, style: "display:none", autocomplete: "off", "aria-hidden": true %>
+    
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: yield(:title),

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,7 +15,7 @@
         <%= render "devise/shared/error_messages", resource: resource %>
       <% end %>
 
-      <%= hidden_field_tag :"user[email]", @login_state.user.email %>
+      <%= email_field_tag :"user[email]", @login_state.user.email, style: "display:none", autocomplete: "off", "aria-hidden": true %>
 
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -27,7 +27,7 @@
         id: "email",
         value: @email,
         error_message: @email_error_message,
-        autocomplete: "email",
+        autocomplete: "username",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
As per Chromium guidance, the hidden input types aren't picked up by most browsers, Firefox and Chrome included:
https://dev.chromium.org/developers/design-documents/form-styles-that-chromium-understands

When setting a new password (for the first time or during a reset) the email should be included in a "hidden" field so password managers know which entry to update (in these cases, I don't know Ruby/devises well enough, so I've left the value field `"USERS-EMAIL-HERE"` which would need setting dynamically server-side)

The "username" autocomplete is compatible with more password managers and is preferred over "email" (as per above link and a blog post here: https://hiddedevries.nl/en/blog/2018-01-13-making-password-managers-play-ball-with-your-login-form)

These changes are influenced by the https://accounts.google.com/signin login HTML elements.

Tested in Chrome, Firefox and Edge using a mock site: https://login-test.cloudapps.digital
(https://gist.github.com/OllieJC/088229f9597c97631c53e1739f2c5660)

Needs work to:
- use a class over in-line CSS for the hidden `email` input
- name in hidden `email` input should match the email input name
- set the hidden `email` input's value in first password entry and resetting password
- ignore the hidden `email` form input from the POST request (user's could change, leading to possible reset/change of another account)